### PR TITLE
clarify wording for force unwrapping impact

### DIFF
--- a/.claude/commands/atlas-impact.md
+++ b/.claude/commands/atlas-impact.md
@@ -400,7 +400,7 @@ interface UserResponse {
 ### Critical Issues 🔴
 
 **Nullability Coverage**: [X]% ([N] files missing NS_ASSUME_NONNULL)
-- **Impact**: Runtime crashes due to `!` force unwrapping
+- **Impact**: Runtime crashes due to force unwrapping operator (!)
 - **Auto-fix**: Run provided sed script to add annotations
 - **Priority**: CRITICAL - Fix before making changes
 


### PR DESCRIPTION
Make the description of the crash cause clearer by replacing the inline `!` notation with the phrase "force unwrapping operator (!)". This improves readability for readers unfamiliar with the code symbol and avoids ambiguity in the Critical Issues section of the atlas-impact command documentation.