### PR TITLE
claude-model-optimization

### DIFF
--- a/.claude/commands/atlas.deps.md
+++ b/.claude/commands/atlas.deps.md
@@ -1,5 +1,6 @@
 ---
 description: Analyze dependency usage for library/framework/SDK upgrades
+model: sonnet
 allowed-tools: Bash, Glob, Grep, Read, WebFetch, WebSearch, AskUserQuestion
 argument-hint: [library or SDK name, e.g., "react", "axios", "iOS 18", "Python 3.12"]
 ---

--- a/.claude/commands/atlas.flow.md
+++ b/.claude/commands/atlas.flow.md
@@ -1,5 +1,6 @@
 ---
 description: Extract business logic flow from code, trace execution path from entry point
+model: opus
 allowed-tools: Bash, Glob, Grep, Read
 argument-hint: [flow description or entry point, e.g., "user checkout", "from OrderService.create()"]
 ---

--- a/.claude/commands/atlas.history.md
+++ b/.claude/commands/atlas.history.md
@@ -1,5 +1,6 @@
 ---
 description: Smart temporal analysis using git history - Hotspots, Coupling, and Recent Contributors
+model: sonnet
 allowed-tools: Bash, Glob, Grep, Read
 argument-hint: (optional) [path or scope, e.g., "src/", "frontend", "last 6 months"]
 ---

--- a/.claude/commands/atlas.impact.md
+++ b/.claude/commands/atlas.impact.md
@@ -1,5 +1,6 @@
 ---
 description: Analyze the impact scope of code changes using static dependency analysis
+model: sonnet
 allowed-tools: Bash, Glob, Grep, Read
 argument-hint: [target, e.g., "User model", "api /api/users/{id}", "authentication"]
 ---

--- a/.claude/commands/atlas.init.md
+++ b/.claude/commands/atlas.init.md
@@ -1,5 +1,6 @@
 ---
 description: Initialize SourceAtlas in current project - inject auto-trigger rules into CLAUDE.md
+model: haiku
 allowed-tools: Read, Write, Edit, Glob
 ---
 

--- a/.claude/commands/atlas.overview.md
+++ b/.claude/commands/atlas.overview.md
@@ -1,5 +1,6 @@
 ---
 description: Get project overview - scan <5% of files to achieve 70-80% understanding
+model: haiku
 allowed-tools: Bash, Glob, Grep, Read, Write
 argument-hint: [path] [--save] (e.g., "src/api" or ". --save")
 ---

--- a/.claude/commands/atlas.overview.md
+++ b/.claude/commands/atlas.overview.md
@@ -1,6 +1,6 @@
 ---
 description: Get project overview - scan <5% of files to achieve 70-80% understanding
-model: haiku
+model: sonnet
 allowed-tools: Bash, Glob, Grep, Read, Write
 argument-hint: [path] [--save] (e.g., "src/api" or ". --save")
 ---

--- a/.claude/commands/atlas.pattern.md
+++ b/.claude/commands/atlas.pattern.md
@@ -1,5 +1,6 @@
 ---
 description: Learn design patterns from the current codebase
+model: sonnet
 allowed-tools: Bash, Glob, Grep, Read
 argument-hint: [pattern type, e.g., "api endpoint", "background job", "file upload"]
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1008,6 +1008,25 @@ touch test-results.md
 - [x] **Branch-Aware Context** - Git 分支/子目錄/Package 偵測 ✅ (2025-12-06)
 - [x] **--save 參數** - 可選儲存至 `.sourceatlas/` ✅ (2025-12-06)
 
+### ✅ 已完成 - Model 效能優化 (2025-12-12)
+
+各命令根據任務複雜度使用不同 Claude 模型，平衡速度與品質：
+
+| 命令 | Model | 原因 |
+|------|-------|------|
+| `/atlas.init` | Haiku | 簡單文字注入，無需推理 |
+| `/atlas.overview` | Sonnet | 假設生成需要中等推理能力 |
+| `/atlas.pattern` | Sonnet | 模式匹配和實作指南生成 |
+| `/atlas.history` | Sonnet | Git 分析和洞察生成 |
+| `/atlas.impact` | Sonnet | 依賴追蹤和風險評估 |
+| `/atlas.deps` | Sonnet | 依賴盤點和規則匹配 |
+| `/atlas.flow` | Opus | 複雜多層邏輯流追蹤（11 種分析模式）|
+
+**預期效益**：
+- Haiku 命令：速度提升 50%+，成本降低 70%
+- Sonnet 命令：速度提升 20-30%，成本降低 40%
+- 整體品質維持高標準（E2E 測試 100% 通過）
+
 ### ✅ 已完成 - 多語言支援
 - [x] iOS/Swift - 34 patterns
 - [x] Kotlin/Android - 31 patterns
@@ -1023,6 +1042,7 @@ touch test-results.md
 - `/atlas.standup` - 整合 GitLab MR 工具（cycle-time, branch-health）
 
 **決策記錄**:
+- (2025-12-12): **Model 效能優化** - 各命令指定最適 Model（Haiku/Sonnet/Opus），E2E 測試 100% 通過
 - (2025-12-08): `/atlas.deps` 設計開始 - 專為 Library/Framework 升級場景（情境 8）
 - (2025-11-25): `/atlas.find` 已取消 - 功能由現有 commands 涵蓋
 - (2025-11-30): `/atlas.history` 實作完成 - 單一命令 + 零參數 + 智慧輸出 + 自動安裝 code-maat

--- a/dev-notes/HISTORY.md
+++ b/dev-notes/HISTORY.md
@@ -8,6 +8,14 @@
 
 ### Week 2 (12/12): v2.9.0 Release - Dependency Analysis ⭐⭐⭐⭐⭐
 
+**Model 效能優化完成** (12/12):
+- 各命令指定最適 Model，平衡速度與品質
+- `/atlas.init`: Haiku（簡單文字注入）
+- `/atlas.overview`, `pattern`, `history`, `impact`, `deps`: Sonnet（中等複雜度分析）
+- `/atlas.flow`: Opus（複雜多層邏輯流追蹤）
+- E2E 測試 100% 通過（7/7 命令）
+- 預期效益：Haiku 成本 -70%、Sonnet 成本 -40%、品質維持高標準
+
 **/atlas.deps 完整測試完成** (12/12):
 - 4 個場景並行測試：iOS 16→17, Android API 35, Kotlin 純粹盤點, Flask 升級
 - **整體準確率**: 100% (42/42 樣本驗證)

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced plugin description to include dependency analysis
 - Updated README with complete `/atlas.deps` documentation
 - Bumped version to 2.9.0 for major feature release
+- **Model Performance Optimization**: Each command now specifies optimal Claude model
+  - `/atlas.init`: Haiku (simple text injection)
+  - `/atlas.overview`, `pattern`, `history`, `impact`, `deps`: Sonnet (moderate complexity)
+  - `/atlas.flow`: Opus (complex multi-layer flow tracing)
+  - Expected benefits: 50%+ faster for Haiku commands, 20-30% faster for Sonnet, 40-70% cost reduction
 
 ### Tested
 - **4 Scenarios**: iOS 16→17, Android API 35, Kotlin coroutines inventory, Flask upgrade

--- a/plugin/commands/atlas.deps.md
+++ b/plugin/commands/atlas.deps.md
@@ -1,5 +1,6 @@
 ---
 description: Analyze dependency usage for library/framework/SDK upgrades
+model: sonnet
 allowed-tools: Bash, Glob, Grep, Read, WebFetch, WebSearch, AskUserQuestion
 argument-hint: [library or SDK name, e.g., "react", "axios", "iOS 18", "Python 3.12"]
 ---

--- a/plugin/commands/atlas.flow.md
+++ b/plugin/commands/atlas.flow.md
@@ -1,5 +1,6 @@
 ---
 description: Extract business logic flow from code, trace execution path from entry point
+model: opus
 allowed-tools: Bash, Glob, Grep, Read
 argument-hint: [flow description or entry point, e.g., "user checkout", "from OrderService.create()"]
 ---

--- a/plugin/commands/atlas.history.md
+++ b/plugin/commands/atlas.history.md
@@ -1,5 +1,6 @@
 ---
 description: Smart temporal analysis using git history - Hotspots, Coupling, and Recent Contributors
+model: sonnet
 allowed-tools: Bash, Glob, Grep, Read
 argument-hint: (optional) [path or scope, e.g., "src/", "frontend", "last 6 months"]
 ---

--- a/plugin/commands/atlas.impact.md
+++ b/plugin/commands/atlas.impact.md
@@ -1,5 +1,6 @@
 ---
 description: Analyze the impact scope of code changes using static dependency analysis
+model: sonnet
 allowed-tools: Bash, Glob, Grep, Read
 argument-hint: [target, e.g., "User model", "api /api/users/{id}", "authentication"]
 ---

--- a/plugin/commands/atlas.init.md
+++ b/plugin/commands/atlas.init.md
@@ -1,5 +1,6 @@
 ---
 description: Initialize SourceAtlas in current project - inject auto-trigger rules into CLAUDE.md
+model: haiku
 allowed-tools: Read, Write, Edit, Glob
 ---
 

--- a/plugin/commands/atlas.overview.md
+++ b/plugin/commands/atlas.overview.md
@@ -1,5 +1,6 @@
 ---
 description: Get project overview - scan <5% of files to achieve 70-80% understanding
+model: sonnet
 allowed-tools: Bash, Glob, Grep, Read
 argument-hint: [optional: specific directory to analyze, e.g., "src/api"]
 ---

--- a/plugin/commands/atlas.pattern.md
+++ b/plugin/commands/atlas.pattern.md
@@ -1,5 +1,6 @@
 ---
 description: Learn design patterns from the current codebase
+model: sonnet
 allowed-tools: Bash, Glob, Grep, Read
 argument-hint: [pattern type, e.g., "api endpoint", "background job", "file upload"]
 ---


### PR DESCRIPTION
## Changes

- Set specific Claude models for atlas commands to improve stability and performance
- Assigned models based on command complexity:
  - Haiku: `/atlas.init`
  - Sonnet: `/atlas.deps`, `/atlas.overview`, `/atlas.history`, `/atlas.impact`, `/atlas.pattern`
  - Opus: `/atlas.flow`
- Updated command front-matter files with model specifications
- Documented model choices in CLAUDE.md and dev-notes/HISTORY.md