### PR TITLE
Mark Python as supported and improve pattern detection

### DIFF
--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -723,7 +723,7 @@ cp scripts/atlas/patterns/ios/networking.sh scripts/atlas/patterns/ios/custom-pa
 - ✅ iOS (Swift + Objective-C)
 - ✅ TypeScript (React + Next.js)
 - ✅ Android (Kotlin)
-- 🔵 Python (in development)
+- ✅ Python (26 patterns)
 - 🔵 Ruby (in development)
 - 🔵 Go (in development)
 

--- a/USAGE_GUIDE.zh-TW.md
+++ b/USAGE_GUIDE.zh-TW.md
@@ -723,7 +723,7 @@ cp scripts/atlas/patterns/ios/networking.sh scripts/atlas/patterns/ios/custom-pa
 - ✅ iOS (Swift + Objective-C)
 - ✅ TypeScript (React + Next.js)
 - ✅ Android (Kotlin)
-- 🔵 Python (開發中)
+- ✅ Python (26 patterns)
 - 🔵 Ruby (開發中)
 - 🔵 Go (開發中)
 


### PR DESCRIPTION
Add Python to the supported list in both English and Traditional Chinese usage guides and note 26 detected patterns. Improve the atlas pattern-finding script to add a second strategy that searches relevant directories for Python files (lower score than exact filename matches) so files like middleware/cors.py are discovered even when they don't match filename patterns. This also avoids duplicates by checking the temp file and retains the original file-name matching strategy.