### PR TITLE
Add Ruby support to pattern detection and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,7 +410,7 @@ This workflow ensures clear feature separation and allows GitButler to automatic
 
 ## Multi-Language Pattern Support
 
-**Total 141 patterns**, covering mainstream tech stacks:
+**Total 167 patterns**, covering mainstream tech stacks:
 
 | Language/Framework | Patterns | Detailed Report |
 |-----------|----------|----------|
@@ -418,6 +418,7 @@ This workflow ensures clear feature separation and allows GitButler to automatic
 | Kotlin/Android | 31 | `dev-notes/2025-11/2025-11-30-kotlin-patterns-implementation-report.md` |
 | Python | 26 | `dev-notes/2025-11/` |
 | TypeScript/React/Vue | 50 | `dev-notes/2025-11/` |
+| Ruby/Rails | 26 | `dev-notes/2025-12/` |
 
 **Methodology**: See `dev-notes/archives/lessons/new-language-support-methodology.md`
 
@@ -478,10 +479,11 @@ Each command uses different Claude models based on task complexity, balancing sp
 - [x] Kotlin/Android - 31 patterns
 - [x] Python - 26 patterns
 - [x] TypeScript/React/Vue - 50 patterns
-- **Total: 141 patterns**
+- [x] Ruby/Rails - 26 patterns
+- **Total: 167 patterns**
 
 ### 🔮 Future (v3.0)
-- Go/Rust/Ruby patterns
+- Go/Rust patterns
 - SourceAtlas Monitor - Continuous tracking and trend analysis
 - Technical debt quantification
 - Health dashboard

--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -724,7 +724,7 @@ cp scripts/atlas/patterns/ios/networking.sh scripts/atlas/patterns/ios/custom-pa
 - ✅ TypeScript (React + Next.js)
 - ✅ Android (Kotlin)
 - ✅ Python (26 patterns)
-- 🔵 Ruby (in development)
+- ✅ Ruby (26 patterns)
 - 🔵 Go (in development)
 
 ### Q: Where are analysis results saved?

--- a/USAGE_GUIDE.zh-TW.md
+++ b/USAGE_GUIDE.zh-TW.md
@@ -724,7 +724,7 @@ cp scripts/atlas/patterns/ios/networking.sh scripts/atlas/patterns/ios/custom-pa
 - ✅ TypeScript (React + Next.js)
 - ✅ Android (Kotlin)
 - ✅ Python (26 patterns)
-- 🔵 Ruby (開發中)
+- ✅ Ruby (26 patterns)
 - 🔵 Go (開發中)
 
 ### Q: 分析結果保存在哪裡？

--- a/scripts/atlas/find-patterns.sh
+++ b/scripts/atlas/find-patterns.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SourceAtlas - Pattern Detection Script (Ultra-Fast Version)
-# Multi-Language Support: Swift/iOS, TypeScript/React, Android/Kotlin, and Python
+# Multi-Language Support: Swift/iOS, TypeScript/React, Android/Kotlin, Python, and Ruby
 #
 # Purpose: Identify files matching a given pattern type using filename/directory matching only
 # Philosophy: Scripts collect data quickly, AI does deep interpretation
@@ -29,7 +29,7 @@ set -euo pipefail
 PATTERN="${1:-}"
 PROJECT_PATH="${2:-.}"
 
-# Detect project type (swift vs typescript vs android vs python)
+# Detect project type (swift vs typescript vs android vs python vs ruby)
 detect_project_type() {
     local path="$1"
 
@@ -45,6 +45,13 @@ detect_project_type() {
     if [ -f "$path/Podfile" ] || [ -f "$path/Package.swift" ] || \
        find "$path" -maxdepth 3 -name "*.xcodeproj" -o -name "*.xcworkspace" 2>/dev/null | grep -q .; then
         echo "swift"
+        return
+    fi
+
+    # Check for Ruby indicators (before Python - Gemfile is very specific)
+    if [ -f "$path/Gemfile" ] || [ -f "$path/config.ru" ] || \
+       [ -f "$path/Rakefile" ] || [ -f "$path/.ruby-version" ]; then
+        echo "ruby"
         return
     fi
 
@@ -261,6 +268,99 @@ get_file_patterns() {
                 ;;
             "spider"|"spiders"|"scrapy"|"crawler")
                 echo "*spider.py *spiders.py *_spider.py *_spiders.py"
+                ;;
+            *)
+                echo ""
+                ;;
+        esac
+    elif [ "$proj_type" = "ruby" ]; then
+        # Ruby/Rails patterns (based on Spree e-commerce analysis)
+        case "$pattern" in
+            # Tier 1 - Core Rails Patterns (14)
+            "controller"|"controllers"|"action controller")
+                echo "*_controller.rb *Controller.rb"
+                ;;
+            "model"|"models"|"active record"|"activerecord")
+                echo "*.rb"
+                # Note: Ruby models often don't have suffix, rely on directory matching
+                ;;
+            "service"|"services"|"service object"|"business logic")
+                echo "*_service.rb *Service.rb"
+                ;;
+            "job"|"jobs"|"background job"|"active job"|"sidekiq"|"worker")
+                echo "*_job.rb *Job.rb *_worker.rb *Worker.rb"
+                ;;
+            "serializer"|"serializers"|"active model serializer"|"jsonapi")
+                echo "*_serializer.rb *Serializer.rb"
+                ;;
+            "mailer"|"mailers"|"action mailer"|"email")
+                echo "*_mailer.rb *Mailer.rb"
+                ;;
+            "concern"|"concerns"|"module"|"mixin")
+                echo "*.rb"
+                # Concerns are modules, rely on directory matching
+                ;;
+            "helper"|"helpers"|"view helper")
+                echo "*_helper.rb *Helper.rb"
+                ;;
+            "decorator"|"decorators"|"presenter"|"presenters"|"draper")
+                echo "*_decorator.rb *Decorator.rb *_presenter.rb *Presenter.rb"
+                ;;
+            "policy"|"policies"|"pundit"|"authorization"|"cancan")
+                echo "*_policy.rb *Policy.rb *_ability.rb ability.rb"
+                ;;
+            "form"|"forms"|"form object"|"reform")
+                echo "*_form.rb *Form.rb"
+                ;;
+            "query"|"queries"|"query object"|"finder")
+                echo "*_query.rb *Query.rb *_finder.rb *Finder.rb"
+                ;;
+            "validator"|"validators"|"custom validator"|"validation")
+                echo "*_validator.rb *Validator.rb"
+                ;;
+            "api"|"api endpoint"|"grape"|"rails api"|"endpoint")
+                echo "*_api.rb *API.rb api.rb"
+                ;;
+
+            # Tier 2 - Supplementary Patterns (12)
+            "spec"|"specs"|"rspec"|"test"|"tests"|"minitest")
+                echo "*_spec.rb *_test.rb spec_helper.rb rails_helper.rb test_helper.rb"
+                ;;
+            "factory"|"factories"|"factory bot"|"fabricator")
+                echo "*_factory.rb factories.rb *_fabricator.rb"
+                ;;
+            "migration"|"migrations"|"active record migration"|"db")
+                echo "*_migration.rb *.rb"
+                # Migrations in db/migrate/, rely on directory matching
+                ;;
+            "rake"|"rake task"|"task"|"tasks")
+                echo "*.rake"
+                ;;
+            "initializer"|"initializers"|"config")
+                echo "*.rb"
+                # Initializers in config/initializers/, rely on directory matching
+                ;;
+            "middleware"|"rack middleware"|"rack")
+                echo "*_middleware.rb *Middleware.rb"
+                ;;
+            "engine"|"engines"|"rails engine"|"mountable")
+                echo "engine.rb *_engine.rb"
+                ;;
+            "observer"|"observers"|"callback")
+                echo "*_observer.rb *Observer.rb *_callback.rb"
+                ;;
+            "uploader"|"uploaders"|"carrierwave"|"shrine"|"active storage")
+                echo "*_uploader.rb *Uploader.rb"
+                ;;
+            "channel"|"channels"|"action cable"|"websocket")
+                echo "*_channel.rb *Channel.rb"
+                ;;
+            "scope"|"scopes"|"named scope")
+                echo "*.rb"
+                # Scopes are in models, rely on directory matching
+                ;;
+            "interactor"|"interactors"|"use case"|"operation")
+                echo "*_interactor.rb *Interactor.rb *_operation.rb *Operation.rb"
                 ;;
             *)
                 echo ""
@@ -716,6 +816,94 @@ get_dir_patterns() {
                 ;;
             "spider"|"spiders"|"scrapy"|"crawler")
                 echo "spiders crawlers"
+                ;;
+            *)
+                echo ""
+                ;;
+        esac
+    elif [ "$proj_type" = "ruby" ]; then
+        # Ruby/Rails directory patterns (based on Spree e-commerce analysis)
+        case "$pattern" in
+            # Tier 1 - Core Rails Patterns (14)
+            "controller"|"controllers"|"action controller")
+                echo "controllers app/controllers"
+                ;;
+            "model"|"models"|"active record"|"activerecord")
+                echo "models app/models"
+                ;;
+            "service"|"services"|"service object"|"business logic")
+                echo "services app/services"
+                ;;
+            "job"|"jobs"|"background job"|"active job"|"sidekiq"|"worker")
+                echo "jobs workers app/jobs app/workers sidekiq"
+                ;;
+            "serializer"|"serializers"|"active model serializer"|"jsonapi")
+                echo "serializers app/serializers"
+                ;;
+            "mailer"|"mailers"|"action mailer"|"email")
+                echo "mailers app/mailers"
+                ;;
+            "concern"|"concerns"|"module"|"mixin")
+                echo "concerns app/models/concerns app/controllers/concerns"
+                ;;
+            "helper"|"helpers"|"view helper")
+                echo "helpers app/helpers"
+                ;;
+            "decorator"|"decorators"|"presenter"|"presenters"|"draper")
+                echo "decorators presenters app/decorators app/presenters"
+                ;;
+            "policy"|"policies"|"pundit"|"authorization"|"cancan")
+                echo "policies app/policies"
+                ;;
+            "form"|"forms"|"form object"|"reform")
+                echo "forms app/forms"
+                ;;
+            "query"|"queries"|"query object"|"finder")
+                echo "queries finders app/queries app/finders"
+                ;;
+            "validator"|"validators"|"custom validator"|"validation")
+                echo "validators app/validators"
+                ;;
+            "api"|"api endpoint"|"grape"|"rails api"|"endpoint")
+                echo "api app/api"
+                ;;
+
+            # Tier 2 - Supplementary Patterns (12)
+            "spec"|"specs"|"rspec"|"test"|"tests"|"minitest")
+                echo "spec test spec/models spec/controllers spec/services spec/requests spec/features"
+                ;;
+            "factory"|"factories"|"factory bot"|"fabricator")
+                echo "factories spec/factories test/factories"
+                ;;
+            "migration"|"migrations"|"active record migration"|"db")
+                echo "migrate db/migrate"
+                ;;
+            "rake"|"rake task"|"task"|"tasks")
+                echo "tasks lib/tasks"
+                ;;
+            "initializer"|"initializers"|"config")
+                echo "initializers config/initializers"
+                ;;
+            "middleware"|"rack middleware"|"rack")
+                echo "middleware app/middleware lib/middleware"
+                ;;
+            "engine"|"engines"|"rails engine"|"mountable")
+                echo "engines"
+                ;;
+            "observer"|"observers"|"callback")
+                echo "observers app/observers"
+                ;;
+            "uploader"|"uploaders"|"carrierwave"|"shrine"|"active storage")
+                echo "uploaders app/uploaders"
+                ;;
+            "channel"|"channels"|"action cable"|"websocket")
+                echo "channels app/channels"
+                ;;
+            "scope"|"scopes"|"named scope")
+                echo "models app/models"
+                ;;
+            "interactor"|"interactors"|"use case"|"operation")
+                echo "interactors operations app/interactors app/operations"
                 ;;
             *)
                 echo ""


### PR DESCRIPTION
Add Ruby/Rails detection and pattern rules to the find-patterns.sh script, and update documentation to list Ruby as a supported language (26 patterns, total patterns updated to 167). This is needed to continue the work of implementing Ruby support: detect Ruby projects via Gemfile/Rakefile/.ruby-version, provide both filename and directory pattern strategies for common Rails concepts (controllers, models, services, jobs, serializers, mailers, concerns, specs, factories, migrations, etc.), and ensure the CLI can locate Ruby-specific files. The docs (CLAUDE.md, USAGE_GUIDE.md and USAGE_GUIDE.zh-TW.md) were updated to reflect Ruby as fully supported and to update the total pattern count.