### PR TITLE
Normalize plugin marketplace name casing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "lis186-sourceatlas",
+  "name": "lis186-SourceAtlas",
   "metadata": {
     "description": "SourceAtlas - AI-powered codebase understanding tools for Claude Code",
     "version": "1.0.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ sourceatlas2/
 /plugin marketplace add lis186/SourceAtlas
 
 # Step 2: Install the plugin
-/plugin install sourceatlas@lis186-sourceatlas
+/plugin install sourceatlas@lis186-SourceAtlas
 
 # Step 3: Start using in any project
 /atlas.overview
@@ -146,10 +146,10 @@ sourceatlas2/
 /plugin
 
 # Update marketplace
-/plugin marketplace update lis186-sourceatlas
+/plugin marketplace update lis186-SourceAtlas
 
 # Uninstall
-/plugin uninstall sourceatlas@lis186-sourceatlas
+/plugin uninstall sourceatlas@lis186-SourceAtlas
 ```
 
 📚 **Official Docs**: See [Claude Code Plugin Documentation](https://code.claude.com/docs/en/plugins)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ claude --plugin-dir ./plugin
 # Option 2: Install via local marketplace
 # In Claude Code:
 /plugin marketplace add ./
-/plugin install sourceatlas@lis186-sourceatlas
+/plugin install sourceatlas@lis186-SourceAtlas
 ```
 
 ### Testing Your Changes

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ SourceAtlas uses **information theory** to prioritize high-entropy files (config
 ```bash
 # In Claude Code:
 /plugin marketplace add lis186/SourceAtlas
-/plugin install sourceatlas@lis186-sourceatlas
+/plugin install sourceatlas@lis186-SourceAtlas
 ```
 
 **Option B: Quick Local Testing**

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -160,7 +160,7 @@ SourceAtlas 使用**資訊理論**優先掃描高熵檔案（configs、READMEs�
 ```bash
 # 在 Claude Code 中執行：
 /plugin marketplace add lis186/SourceAtlas
-/plugin install sourceatlas@lis186-sourceatlas
+/plugin install sourceatlas@lis186-SourceAtlas
 ```
 
 **方法 B：本地快速測試**

--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -95,7 +95,7 @@ SourceAtlas is suitable for the following common scenarios:
 ```bash
 # In Claude Code:
 /plugin marketplace add lis186/SourceAtlas
-/plugin install sourceatlas@lis186-sourceatlas
+/plugin install sourceatlas@lis186-SourceAtlas
 ```
 
 For local development/testing:

--- a/USAGE_GUIDE.zh-TW.md
+++ b/USAGE_GUIDE.zh-TW.md
@@ -95,7 +95,7 @@ SourceAtlas 適用於以下常見情境：
 ```bash
 # 在 Claude Code 中執行：
 /plugin marketplace add lis186/SourceAtlas
-/plugin install sourceatlas@lis186-sourceatlas
+/plugin install sourceatlas@lis186-SourceAtlas
 ```
 
 本地開發/測試：

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Official Plugin Marketplace** - Now installable via Claude Code plugin system ⭐
   ```bash
   /plugin marketplace add lis186/SourceAtlas
-  /plugin install sourceatlas@lis186-sourceatlas
+  /plugin install sourceatlas@lis186-SourceAtlas
   ```
 - **`.claude-plugin/marketplace.json`** - Marketplace manifest for plugin distribution
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -39,7 +39,7 @@ No need to remember commands — just ask naturally!
 /plugin marketplace add lis186/SourceAtlas
 
 # Step 2: Install the plugin
-/plugin install sourceatlas@lis186-sourceatlas
+/plugin install sourceatlas@lis186-SourceAtlas
 
 # Step 3: Start using in any project
 /atlas.overview
@@ -58,7 +58,7 @@ claude --plugin-dir ./plugin
 
 # Or add as local marketplace
 /plugin marketplace add ./path/to/SourceAtlas
-/plugin install sourceatlas@lis186-sourceatlas
+/plugin install sourceatlas@lis186-SourceAtlas
 ```
 
 ## 📖 Usage
@@ -374,7 +374,7 @@ claude --plugin-dir ./plugin
 # Option 2: Local marketplace
 # From the SourceAtlas repository root:
 /plugin marketplace add ./
-/plugin install sourceatlas@lis186-sourceatlas
+/plugin install sourceatlas@lis186-SourceAtlas
 
 # Test in any project
 cd ~/your-project
@@ -383,8 +383,8 @@ cd ~/your-project
 /atlas.impact "User model"
 
 # After making changes to plugin/
-/plugin uninstall sourceatlas@lis186-sourceatlas
-/plugin install sourceatlas@lis186-sourceatlas
+/plugin uninstall sourceatlas@lis186-SourceAtlas
+/plugin install sourceatlas@lis186-SourceAtlas
 ```
 
 ## 🤝 Contributing


### PR DESCRIPTION
Fix inconsistent casing of the plugin identifier to match the marketplace manifest (lis186-SourceAtlas). The marketplace.json manifest uses "lis186-SourceAtlas", but various docs and install/uninstall/update commands used the lowercase "lis186-sourceatlas", which caused a filesystem rename error on case-sensitive systems. Update all documentation and examples to use the exact casing to prevent ENOENT/rename failures when adding, installing, updating, or uninstalling the plugin.