### PR TITLE
docs: Refine acknowledgments section wording in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ All commands support `--save`:
 
 ## Acknowledgments
 
-SourceAtlas is built on these excellent open-source tools:
+SourceAtlas is built with these excellent tools:
 
 | Tool | Purpose | Link |
 |------|---------|------|

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -292,7 +292,7 @@ cd ~/projects/any-project
 
 ## 致謝
 
-SourceAtlas 建立在這些優秀的開源工具之上：
+SourceAtlas 建立在這些優秀的工具之上：
 
 | 工具 | 用途 | 連結 |
 |------|------|------|


### PR DESCRIPTION
Improve language in acknowledgments section to be more concise
and clear across both English and Traditional Chinese README
documents. Remove explicit "open-source" reference while
maintaining the core meaning.