### PR TITLE
Document Claude Code --scope project installation issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ git clone https://github.com/lis186/SourceAtlas.git
 claude --plugin-dir ./SourceAtlas/plugin
 ```
 
+> ⚠️ **Known Issue**: If you install with `--scope project` in one repo, you may get "already installed" errors in other repos. This is a [Claude Code bug](https://github.com/anthropics/claude-code/issues/14202). **Workaround**: Use default user scope (no `--scope` flag) or `--scope user`.
+
 ### First Use
 
 ```bash

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -169,6 +169,8 @@ git clone https://github.com/lis186/SourceAtlas.git
 claude --plugin-dir ./SourceAtlas/plugin
 ```
 
+> ⚠️ **已知問題**：若使用 `--scope project` 安裝後，在其他 repo 可能會遇到 "already installed" 錯誤。這是 [Claude Code 的 bug](https://github.com/anthropics/claude-code/issues/14202)。**解法**：使用預設的 user scope（不加 `--scope` 參數）。
+
 ### 第一次使用
 
 ```bash

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -50,6 +50,8 @@ No need to remember commands — just ask naturally!
 - **User scope** (default): Available across all your projects
 - **Project scope**: `--scope project` to share with collaborators
 
+> ⚠️ **Known Issue**: If you install with `--scope project` in one repo, you may get "already installed" errors in other repos. This is a [Claude Code bug](https://github.com/anthropics/claude-code/issues/14202). **Workaround**: Use default user scope (no `--scope` flag).
+
 ### Method 2: Local Development/Testing
 
 ```bash


### PR DESCRIPTION
Warn about a known Claude Code bug that can cause "already installed" errors when installing plugins with --scope project. Add a clear workaround recommending the default user scope (no --scope flag) and link to the upstream issue for reference. Apply the note to README.md, README.zh-TW.md, and plugin/README.md.