### PR TITLE
Update OpenSkills install path in docs

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **OpenSkills Cross-Platform Support** - SourceAtlas now works with Cursor, Gemini CLI, Aider, Windsurf ⭐ Major Feature
   - Commands converted to `{name}/SKILL.md` directory format
   - Compatible with [OpenSkills](https://github.com/numman-ali/openskills) universal skills loader
-  - Install via: `openskills install lis186/SourceAtlas/plugin/commands`
+  - Install via: `openskills install lis186/SourceAtlas`
 - **Detailed Cursor Usage Guide** - Step-by-step instructions for Cursor users in README
 
 ### Changed

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -62,7 +62,7 @@ npm i -g openskills
 
 # Step 2: In your project directory, install SourceAtlas skills
 cd your-project
-openskills install lis186/SourceAtlas/plugin/commands
+openskills install lis186/SourceAtlas
 
 # Step 3: Create/update AGENTS.md (your AI agent reads this file)
 touch AGENTS.md

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -50,7 +50,7 @@ SourceAtlas 未來功能的完整設計文檔。
   - **完成日期**: 2026-01-10
   - **成果**: 8 個 commands 轉換為 `{name}/SKILL.md` 目錄格式
   - **支援**: Claude Code + Cursor + Gemini CLI + Windsurf + Aider
-  - **安裝**: `openskills install lis186/SourceAtlas/plugin/commands`
+  - **安裝**: `openskills install lis186/SourceAtlas`
 
 ### 🔵 待評估
 


### PR DESCRIPTION
• Updated documentation and changelog to use repository root for OpenSkills installation
• Aligned install instructions with the actual package location (lis186/SourceAtlas)
• Reflected conversion of commands to the {name}/SKILL.md layout